### PR TITLE
Adds support for Adhoc filtering for Redis datasource

### DIFF
--- a/src/datasources/lib/models/datasource.ts
+++ b/src/datasources/lib/models/datasource.ts
@@ -9,7 +9,7 @@ export enum TargetFormat {
 }
 
 export interface Query {
-    app: string,
+    app: string;
     dashboardId: number;
     panelId: number;
     timezone: string;

--- a/src/datasources/lib/models/datasource.ts
+++ b/src/datasources/lib/models/datasource.ts
@@ -9,6 +9,7 @@ export enum TargetFormat {
 }
 
 export interface Query {
+    app: string,
     dashboardId: number;
     panelId: number;
     timezone: string;

--- a/src/datasources/lib/models/variables.ts
+++ b/src/datasources/lib/models/variables.ts
@@ -1,0 +1,33 @@
+export enum DashboardVariableType {
+    Constant = 'constant',
+    AdHoc = 'adhoc',
+    Interval = 'interval',
+    Query = 'query',
+    Datasource = 'datasource',
+    Custom = 'custom',
+    TextBox = 'textbox',
+}
+
+export interface DashboardVariable {
+    type: DashboardVariableType,
+    [key: string]: any,
+}
+
+export interface AdHocFilter {
+    condition: string,
+    key: string,
+    operator: string,
+    value: string,
+}
+
+export interface AdHocDashboardVariable {
+    $$haskey: string,
+    datasource: string,
+    defaults: any,
+    filters: Array<AdHocFilter>,
+    hide: boolean,
+    label: string | null,
+    name: string,
+    skipUrlSync: boolean,
+    type: DashboardVariableType,
+}

--- a/src/datasources/lib/models/variables.ts
+++ b/src/datasources/lib/models/variables.ts
@@ -16,7 +16,7 @@ export interface DashboardVariable {
 export interface AdHocFilter {
     condition: string,
     key: string,
-    operator: string,
+    operator: DashboardVariableFilterOperator,
     value: string,
 }
 
@@ -30,4 +30,13 @@ export interface AdHocDashboardVariable {
     name: string,
     skipUrlSync: boolean,
     type: DashboardVariableType,
+}
+
+export enum DashboardVariableFilterOperator {
+    Equals = '=',
+    NotEquals = '!=',
+    LessThan = '<',
+    GreaterThan = '>',
+    RegexMatch = '=~',
+    RegexNotMatch = '!~',
 }

--- a/src/datasources/lib/models/variables.ts
+++ b/src/datasources/lib/models/variables.ts
@@ -9,27 +9,27 @@ export enum DashboardVariableType {
 }
 
 export interface DashboardVariable {
-    type: DashboardVariableType,
-    [key: string]: any,
+    type: DashboardVariableType;
+    [key: string]: any;
 }
 
 export interface AdHocFilter {
-    condition: string,
-    key: string,
-    operator: DashboardVariableFilterOperator,
-    value: string,
+    condition: string;
+    key: string;
+    operator: DashboardVariableFilterOperator;
+    value: string;
 }
 
 export interface AdHocDashboardVariable {
-    $$haskey: string,
-    datasource: string,
-    defaults: any,
-    filters: Array<AdHocFilter>,
-    hide: boolean,
-    label: string | null,
-    name: string,
-    skipUrlSync: boolean,
-    type: DashboardVariableType,
+    $$haskey: string;
+    datasource: string;
+    defaults: any;
+    filters: Array<AdHocFilter>;
+    hide: boolean;
+    label: string | null;
+    name: string;
+    skipUrlSync: boolean;
+    type: DashboardVariableType;
 }
 
 export enum DashboardVariableFilterOperator {

--- a/src/datasources/lib/models/variables.ts
+++ b/src/datasources/lib/models/variables.ts
@@ -21,7 +21,6 @@ export interface AdHocFilter {
 }
 
 export interface AdHocDashboardVariable {
-    $$haskey: string;
     datasource: string;
     defaults: any;
     filters: Array<AdHocFilter>;

--- a/src/datasources/lib/specs/lib/fixtures/grafana.ts
+++ b/src/datasources/lib/specs/lib/fixtures/grafana.ts
@@ -25,6 +25,7 @@ export const metricMetadataIndom: MetricMetadata = {
 };
 
 export const query: Query = {
+    app: 'dashboard',
     dashboardId: 1,
     panelId: 1,
     timezone: "",

--- a/src/datasources/lib/specs/lib/fixtures/grafana.ts
+++ b/src/datasources/lib/specs/lib/fixtures/grafana.ts
@@ -25,7 +25,7 @@ export const metricMetadataIndom: MetricMetadata = {
 };
 
 export const query: Query = {
-    app: 'dashboard',
+    app: "dashboard",
     dashboardId: 1,
     panelId: 1,
     timezone: "",

--- a/src/datasources/lib/utils.ts
+++ b/src/datasources/lib/utils.ts
@@ -60,19 +60,20 @@ export function getDashboardVariables(variableSrv: any) {
 
 export function getAdHocFilters(datasourceName: string | null, variables: Array<DashboardVariable>): Array<AdHocFilter> {
     let filters: Array<AdHocFilter> = [];
-    if (variables) {
-        variables.forEach(variable => {
-            if (variable.type !== DashboardVariableType.AdHoc) {
-                return;
-            }
-            const adHocVariable: AdHocDashboardVariable = variable as AdHocDashboardVariable;
-            const isMatchingDatasource = adHocVariable.datasource === null || adHocVariable.datasource === datasourceName;
-            if (isMatchingDatasource) {
-                const variableFilters = variable.filters;
-                filters = filters.concat(variableFilters);
-            }
-        });
+    if (!variables) {
+        return filters;
     }
+    variables.forEach(variable => {
+        if (variable.type !== DashboardVariableType.AdHoc) {
+            return;
+        }
+        const adHocVariable: AdHocDashboardVariable = variable as AdHocDashboardVariable;
+        const isMatchingDatasource = adHocVariable.datasource === null || adHocVariable.datasource === datasourceName;
+        if (isMatchingDatasource) {
+            const variableFilters = variable.filters;
+            filters = filters.concat(variableFilters);
+        }
+    });
     return filters;
 }
 

--- a/src/datasources/lib/utils.ts
+++ b/src/datasources/lib/utils.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { 
+import {
     DashboardVariable,
     DashboardVariableType,
     AdHocDashboardVariable,
@@ -60,20 +60,20 @@ export function getDashboardVariables(variableSrv: any) {
 
 export function getAdHocFilters(datasourceName: string | null, variables: Array<DashboardVariable>): Array<AdHocFilter> {
     let filters: Array<AdHocFilter> = [];
-	if (variables) {
+    if (variables) {
         variables.forEach(variable => {
             if (variable.type !== DashboardVariableType.AdHoc) {
                 return;
             }
             const adHocVariable: AdHocDashboardVariable = variable as AdHocDashboardVariable;
-            const isMatchingDatasource = adHocVariable.datasource === null || adHocVariable.datasource === datasourceName;            
+            const isMatchingDatasource = adHocVariable.datasource === null || adHocVariable.datasource === datasourceName;
             if (isMatchingDatasource) {
                 const variableFilters = variable.filters;
                 filters = filters.concat(variableFilters);
             }
         });
-	}
-	return filters;
+    }
+    return filters;
 }
 
 export function versionCmp(v1: string, v2: string): number {

--- a/src/datasources/lib/utils.ts
+++ b/src/datasources/lib/utils.ts
@@ -38,8 +38,6 @@ export function getDashboardVariables(variableSrv: any) {
         // variables are not defined on the datasource settings page
         return {};
     }
-
-    // TODO: fix this breaking when adhoc filtering varibale is set
     variableSrv.variables.forEach((variable: DashboardVariable) => {
         if (variable.type === DashboardVariableType.AdHoc) return;
         let variableValue = variable.current.value;

--- a/src/datasources/lib/utils.ts
+++ b/src/datasources/lib/utils.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { DashboardVariable, DashboardVariableType } from './models/variables';
 
 // typescript decorator which makes sure that this function
 // is called only once at a time
@@ -34,7 +35,8 @@ export function getDashboardVariables(variableSrv: any) {
     }
 
     // TODO: fix this breaking when adhoc filtering varibale is set
-    variableSrv.variables.forEach((variable: any) => {
+    variableSrv.variables.forEach((variable: DashboardVariable) => {
+        if (variable.type === DashboardVariableType.AdHoc) return;
         let variableValue = variable.current.value;
         if (variableValue === '$__all' || _.isEqual(variableValue, ['$__all'])) {
             if (variable.allValue === null) {
@@ -51,6 +53,23 @@ export function getDashboardVariables(variableSrv: any) {
     });
 
     return variables;
+}
+
+export function getAdHocFilters(datasourceName: string | null, variables: Array<any>) {
+    let filters: any = [];
+	if (variables) {
+		for (let i = 0; i < variables.length; i++) {
+			const variable = variables[i];
+			if (variable.type !== DashboardVariableType.AdHoc) {
+				continue;
+			}
+			if (variable.datasource === null || variable.datasource === datasourceName) {
+				filters = filters.concat(variable.filters);
+			}
+		}
+	}
+
+	return filters;
 }
 
 export function versionCmp(v1: string, v2: string): number {

--- a/src/datasources/lib/utils.ts
+++ b/src/datasources/lib/utils.ts
@@ -1,5 +1,10 @@
 import _ from "lodash";
-import { DashboardVariable, DashboardVariableType } from './models/variables';
+import { 
+    DashboardVariable,
+    DashboardVariableType,
+    AdHocDashboardVariable,
+    AdHocFilter,
+} from './models/variables';
 
 // typescript decorator which makes sure that this function
 // is called only once at a time
@@ -55,20 +60,21 @@ export function getDashboardVariables(variableSrv: any) {
     return variables;
 }
 
-export function getAdHocFilters(datasourceName: string | null, variables: Array<any>) {
-    let filters: any = [];
+export function getAdHocFilters(datasourceName: string | null, variables: Array<DashboardVariable>): Array<AdHocFilter> {
+    let filters: Array<AdHocFilter> = [];
 	if (variables) {
-		for (let i = 0; i < variables.length; i++) {
-			const variable = variables[i];
-			if (variable.type !== DashboardVariableType.AdHoc) {
-				continue;
-			}
-			if (variable.datasource === null || variable.datasource === datasourceName) {
-				filters = filters.concat(variable.filters);
-			}
-		}
+        variables.forEach(variable => {
+            if (variable.type !== DashboardVariableType.AdHoc) {
+                return;
+            }
+            const adHocVariable: AdHocDashboardVariable = variable as AdHocDashboardVariable;
+            const isMatchingDatasource = adHocVariable.datasource === null || adHocVariable.datasource === datasourceName;            
+            if (isMatchingDatasource) {
+                const variableFilters = variable.filters;
+                filters = filters.concat(variableFilters);
+            }
+        });
 	}
-
 	return filters;
 }
 

--- a/src/datasources/lib/utils.ts
+++ b/src/datasources/lib/utils.ts
@@ -33,6 +33,7 @@ export function getDashboardVariables(variableSrv: any) {
         return {};
     }
 
+    // TODO: fix this breaking when adhoc filtering varibale is set
     variableSrv.variables.forEach((variable: any) => {
         let variableValue = variable.current.value;
         if (variableValue === '$__all' || _.isEqual(variableValue, ['$__all'])) {

--- a/src/datasources/redis/datasource.ts
+++ b/src/datasources/redis/datasource.ts
@@ -204,7 +204,6 @@ export class PCPRedisDatasource {
             return { data: [] };
         if (!_.every(targets, ['format', targets[0].format]))
             throw new Error("Format must be the same for all queries of a panel.");
-        
         const datasourceName = this.name;
         const variables = this.templateSrv.variables;
         const adHocFilters = getAdHocFilters(datasourceName, variables);

--- a/src/datasources/redis/datasource.ts
+++ b/src/datasources/redis/datasource.ts
@@ -199,7 +199,6 @@ export class PCPRedisDatasource {
     }
 
     async query(query: Query) {
-        console.log(query);
         const targets = this.buildQueryTargets(query);
         if (targets.length === 0)
             return { data: [] };

--- a/src/datasources/redis/datasource.ts
+++ b/src/datasources/redis/datasource.ts
@@ -182,7 +182,7 @@ export class PCPRedisDatasource {
         const hasMetadata = openingBracketIndex !== -1;
         const filterCount = filters.length;
         const adHocFilterStr = filters.reduce((previousValue, filter, index) => {
-            const modifiedOperator = filter.operator == DashboardVariableFilterOperator.Equals ? '==' : filter.operator;
+            const modifiedOperator = filter.operator === DashboardVariableFilterOperator.Equals ? '==' : filter.operator;
             const comma = index !== filterCount - 1 ? ',' : '';
             const isNumericValue = !isNaN(parseFloat(filter.value)) && isFinite(+filter.value);
             const formattedValue = isNumericValue ? filter.value : `"${filter.value}"`;
@@ -190,7 +190,7 @@ export class PCPRedisDatasource {
         }, '');
         let newExpr;
         if (hasMetadata) {
-            let appendPoint = openingBracketIndex + 1;
+            const appendPoint = openingBracketIndex + 1;
             newExpr = `${expr.substring(0, appendPoint)}${adHocFilterStr},${expr.substring(appendPoint)}`;
         } else {
             newExpr = `${expr}{${adHocFilterStr}}`;

--- a/src/datasources/redis/datasource.ts
+++ b/src/datasources/redis/datasource.ts
@@ -158,6 +158,21 @@ export class PCPRedisDatasource {
         return label;
     }
 
+    async getTagKeys() {
+        const result = await this.pmSeriesSrv.getLabelsNames();
+        const keys = result.map(x => ({
+            type: 'string',
+            text: x
+        }));
+        return keys;
+    }
+
+    async getTagValues(option: any) {
+        const result = await this.pmSeriesSrv.getLabelValues([option.key]);
+        const values = result[option.key].map(x => ({ text: x }));
+        return values;
+    }
+
     async query(query: Query) {
         const targets = this.buildQueryTargets(query);
         if (targets.length === 0)

--- a/src/datasources/redis/datasource.ts
+++ b/src/datasources/redis/datasource.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { isBlank } from '../lib/utils';
+import { isBlank, getAdHocFilters } from '../lib/utils';
 import { PmSeriesSrv } from './pmseries_srv';
 import PanelTransformations from '../lib/services/panel_transformation_srv';
 import { ValueTransformationSrv } from '../lib/services/value_transformation_srv';
@@ -178,13 +178,16 @@ export class PCPRedisDatasource {
         if (targets.length === 0)
             return { data: [] };
         if (!_.every(targets, ['format', targets[0].format]))
-            throw new Error("Format must be the same for all queries of a panel.");
-
+        throw new Error("Format must be the same for all queries of a panel.");
+        
         const exprs = targets.map(target => target.expr);
         const series = await Promise.all(exprs.map(expr => this.pmSeriesSrv.query(expr)));
         const seriesByExpr = _.zipObject(exprs, series);
         const seriesList = series.flat();
-
+        const datasourceName = this.name;
+        const variables = this.templateSrv.variables;
+        const adHocFilters = getAdHocFilters(datasourceName, variables);
+        console.log(adHocFilters);
         for (const expr in seriesByExpr) {
             if (seriesByExpr[expr].length === 0) {
                 throw new Error(`Could not find any series for ${expr}`);

--- a/src/datasources/redis/datasource.ts
+++ b/src/datasources/redis/datasource.ts
@@ -8,6 +8,7 @@ import { TargetResult, Metric, MetricInstance, Labels } from '../lib/models/metr
 import { MetricValue } from './models/pmseries';
 import { NetworkError } from '../lib/models/errors';
 import "core-js/stable/array/flat";
+import { DashboardVariableFilterOperator, AdHocFilter } from '../lib/models/variables';
 
 export class PCPRedisDatasource {
 
@@ -178,16 +179,16 @@ export class PCPRedisDatasource {
         if (targets.length === 0)
             return { data: [] };
         if (!_.every(targets, ['format', targets[0].format]))
-        throw new Error("Format must be the same for all queries of a panel.");
+            throw new Error("Format must be the same for all queries of a panel.");
         
-        const exprs = targets.map(target => target.expr);
-        const series = await Promise.all(exprs.map(expr => this.pmSeriesSrv.query(expr)));
-        const seriesByExpr = _.zipObject(exprs, series);
-        const seriesList = series.flat();
         const datasourceName = this.name;
         const variables = this.templateSrv.variables;
         const adHocFilters = getAdHocFilters(datasourceName, variables);
         console.log(adHocFilters);
+        const exprs = targets.map(target => target.expr);
+        const series = await Promise.all(exprs.map(expr => this.pmSeriesSrv.query(expr)));
+        const seriesByExpr = _.zipObject(exprs, series);
+        const seriesList = series.flat();
         for (const expr in seriesByExpr) {
             if (seriesByExpr[expr].length === 0) {
                 throw new Error(`Could not find any series for ${expr}`);

--- a/src/datasources/redis/datasource.ts
+++ b/src/datasources/redis/datasource.ts
@@ -160,7 +160,7 @@ export class PCPRedisDatasource {
     }
 
     async getTagKeys() {
-        const result = await this.pmSeriesSrv.getLabelsNames();
+        const result = await this.pmSeriesSrv.getLabelNames();
         const keys = result.map(x => ({
             type: 'string',
             text: x

--- a/src/datasources/redis/pmseries_srv.ts
+++ b/src/datasources/redis/pmseries_srv.ts
@@ -192,9 +192,7 @@ export class PmSeriesSrv {
 
     async getLabels(series: string[]): Promise<Record<string, Labels>> {
         const requiredSeries = _.difference(series, Object.keys(this.labelCache));
-        const notCachedLabelsRequested = requiredSeries.length > 0;
-        const isGetAllQuery = series.length == 0;
-        if (notCachedLabelsRequested || isGetAllQuery) {
+        if (requiredSeries.length > 0) {
             const response = await this.pmSeriesApi.labels(series);
             for (const labels of response) {
                 this.labelCache[labels.series] = labels.labels;

--- a/src/datasources/redis/pmseries_srv.ts
+++ b/src/datasources/redis/pmseries_srv.ts
@@ -93,14 +93,14 @@ class PmSeriesApi {
         return response.data;
     }
 
-    async labelsNames(): Promise<string[]> {
+    async labelNames(): Promise<string[]> {
         const response = await this.datasourceRequest({
             url: `${this.url}/series/labels`,
         });
         return response.data;
     }
 
-    async labelsValues(names: string[]): Promise<LabelsValuesResponse> {
+    async labelValues(names: string[]): Promise<LabelsValuesResponse> {
         const response = await this.datasourceRequest({
             url: `${this.url}/series/labels`,
             params: { names: names.join(',') },
@@ -201,12 +201,12 @@ export class PmSeriesSrv {
         return _.pick(this.labelCache, series);
     }
 
-    async getLabelsNames(): Promise<string[]> {
-        return await this.pmSeriesApi.labelsNames();
+    async getLabelNames(): Promise<string[]> {
+        return await this.pmSeriesApi.labelNames();
     }
 
     async getLabelValues(names: string[]): Promise<LabelsValuesResponse> {
-        return await this.pmSeriesApi.labelsValues(names);
+        return await this.pmSeriesApi.labelValues(names);
     }
 
     async getMetricAndInstanceLabels(series: string[]): Promise<Record<string, Labels>> {


### PR DESCRIPTION
Some things to note:

- https://github.com/Erbenos/grafana-pcp/blob/e399dcdfe4da370f826e5a8747e20f920cce2351/src/datasources/redis/datasource.ts#L187 what is assumed to be numerical value has quotes ommited in http://man7.org/linux/man-pages/man1/pmseries.1.html metadata qualifiers around metadata value. This may have cause unexpected behavior, when one wishes to compare against strings containing purely numerical values. Eg. hostname=="0" gets processed as hostname==0. Making the intended comparison fail.
- while I did run `yarn run test` and all have passed, there is no test for these filters, pointers where/how to write them are welcome