### PR TITLE
modify table in redis.rst

### DIFF
--- a/docs/datasources/redis.rst
+++ b/docs/datasources/redis.rst
@@ -69,9 +69,14 @@ Query Functions
 ---------------
 The following functions are available for dashboard variables of type *Query*:
 
-=============================== ================================================================================================ =======================
-Function                        Description                                                                                      Example
-=============================== ================================================================================================ =======================
-``metrics([pattern])``          returns all metrics matching a glob pattern (if no pattern is defined, all metrics are returned) ``metrics(disk.*)``
-``label_values(metric, label)`` returns all label values for the specified label of the specified metric                         ``label_values(kernel.all.uptime, hostname)``
-=============================== ================================================================================================ =======================
+=============================== ============================= =======================
+Function                        Description                   Example
+=============================== ============================= =======================
+``metrics([pattern])``          | returns all metrics         ``metrics(disk.*)``
+                                | matching a glob pattern      
+                                | (if no pattern is defined,           
+                                | all metrics are returned)	   
+``label_values(metric, label)`` | returns all label values    ``label_values(kernel.all.uptime, hostname)``
+                                | for the specified label          
+                                | of the specified metric          
+=============================== ============================= =======================


### PR DESCRIPTION
Hi @andreasgerstmayr and @natoscott! As I applied the PCP Grafana documentation project for Google Season of Docs, I was reviewing current Grafana documentation and I found that in the PCP redis document, text in table cells does not to wrap. Therefore, I modified the table to get rid of the scrollbar. The snapshot below is what the modified table looks like.
![image](https://user-images.githubusercontent.com/42322196/87269921-a2977a80-c49c-11ea-92e7-1b7f8ad29db3.png)