### PR TITLE
vector datasource: derived metrics + related qa

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "node": ">=12 <13"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.4.0",
     "blueimp-md5": "^2.17.0",
     "core-js": "^3.6.5",
     "d3-flame-graph": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">=12 <13"
   },
   "dependencies": {
-    "@reduxjs/toolkit": "^1.4.0",
+    "blueimp-md5": "^2.17.0",
     "core-js": "^3.6.5",
     "d3-flame-graph": "^3.1.1",
     "emotion": "^10.0.27",

--- a/src/datasources/bpftrace/datasource.ts
+++ b/src/datasources/bpftrace/datasource.ts
@@ -100,7 +100,8 @@ export class DataSource extends DataSourceApi<BPFtraceQuery, BPFtraceOptions> {
             throw new Error(`BPFtrace error:\n\n${script.state.error}`);
         }
         target.custom = { script };
-        return this.state.scriptManager.getMetrics(target.custom.script, target.query.format);
+        const metrics = this.state.scriptManager.getMetrics(target.custom.script, target.query.format);
+        return { metrics };
     }
 
     deregisterTarget(target: PmapiTarget<BPFtraceTargetData>) {

--- a/src/datasources/bpftrace/datasource.ts
+++ b/src/datasources/bpftrace/datasource.ts
@@ -100,8 +100,7 @@ export class DataSource extends DataSourceApi<BPFtraceQuery, BPFtraceOptions> {
             throw new Error(`BPFtrace error:\n\n${script.state.error}`);
         }
         target.custom = { script };
-        const metrics = this.state.scriptManager.getMetrics(target.custom.script, target.query.format);
-        return metrics;
+        return this.state.scriptManager.getMetrics(target.custom.script, target.query.format);
     }
 
     deregisterTarget(target: PmapiTarget<BPFtraceTargetData>) {

--- a/src/datasources/bpftrace/datasource.ts
+++ b/src/datasources/bpftrace/datasource.ts
@@ -101,7 +101,7 @@ export class DataSource extends DataSourceApi<BPFtraceQuery, BPFtraceOptions> {
         }
         target.custom = { script };
         const metrics = this.state.scriptManager.getMetrics(target.custom.script, target.query.format);
-        return { metrics };
+        return metrics;
     }
 
     deregisterTarget(target: PmapiTarget<BPFtraceTargetData>) {

--- a/src/datasources/lib/pmapi.ts
+++ b/src/datasources/lib/pmapi.ts
@@ -20,6 +20,7 @@ interface MetricsResponse {
 }
 
 interface MetricInstanceValues {
+    pmapi: string;
     name: MetricName;
     instances: PmapiInstanceValue[];
 }
@@ -33,11 +34,21 @@ interface StoreResponse {
     success: boolean;
 }
 
+interface DeriveResponse extends StoreResponse {}
+
 export class MetricNotFoundError extends Error {
     constructor(readonly metric: string, message?: string) {
         super(message ?? `Cannot find metric ${metric}. Please check if the PMDA is enabled.`);
         this.metric = metric;
         Object.setPrototypeOf(this, MetricNotFoundError.prototype);
+    }
+}
+
+export class DuplicateDerivedMetricNameError extends Error {
+    constructor(readonly metric: string, message?: string) {
+        super(message ?? `Duplicate derived metric name ${metric}`);
+        this.metric = metric;
+        Object.setPrototypeOf(this, DuplicateDerivedMetricNameError.prototype);
     }
 }
 
@@ -145,6 +156,22 @@ export class PmApi {
                 throw new PermissionError(name);
             } else if (has(error, 'data.message') && error.data.message.includes('Bad input')) {
                 return { success: false };
+            } else {
+                throw error;
+            }
+        }
+    }
+
+    async createDerived(url: string, expr: string, name: string): Promise<DeriveResponse> {
+        try {
+            const response = await this.datasourceRequest({
+                url: `${url}/pmapi/derive`,
+                params: { name, expr },
+            });
+            return response.data;
+        } catch (error) {
+            if (has(error, 'data.message') && error.data.message.includes('Duplicate derived metric name')) {
+                return { success: true };
             } else {
                 throw error;
             }

--- a/src/datasources/lib/pmapi.ts
+++ b/src/datasources/lib/pmapi.ts
@@ -20,7 +20,6 @@ interface MetricsResponse {
 }
 
 interface MetricInstanceValues {
-    pmapi: string;
     name: MetricName;
     instances: PmapiInstanceValue[];
 }
@@ -162,10 +161,11 @@ export class PmApi {
         }
     }
 
-    async createDerived(url: string, expr: string, name: string): Promise<DeriveResponse> {
+    async createDerived(url: string, ctxid: number | null, expr: string, name: string): Promise<DeriveResponse> {
+        const ctxPath = ctxid == null ? '' : `/${ctxid}`;
         try {
             const response = await this.datasourceRequest({
-                url: `${url}/pmapi/derive`,
+                url: `${url}/pmapi${ctxPath}/derive`,
                 params: { name, expr },
             });
             return response.data;

--- a/src/datasources/lib/poller.ts
+++ b/src/datasources/lib/poller.ts
@@ -55,7 +55,7 @@ export interface Endpoint<T = Dict<string, any>> {
 interface PollerHooks {
     queryHasChanged: (prevQuery: CompletePmapiQuery, newQuery: CompletePmapiQuery) => boolean;
     registerEndpoint?: (endpoint: Endpoint) => Promise<void>;
-    registerTarget: (target: PmapiTarget) => Promise<string[]>;
+    registerTarget: (target: PmapiTarget, endpoint: Endpoint) => Promise<string[]>;
     deregisterTarget?: (target: PmapiTarget) => void;
     redisBackfill?: (endpoint: Endpoint, targets: PmapiTarget[]) => Promise<void>;
 }
@@ -160,7 +160,7 @@ export class Poller {
         await Promise.all(
             pendingTargets.map(target =>
                 this.hooks
-                    .registerTarget(target)
+                    .registerTarget(target, endpoint)
                     .then(metricNames => (target.metricNames = metricNames))
                     .catch(error => {
                         target.state = PmapiTargetState.ERROR;

--- a/src/datasources/lib/poller.ts
+++ b/src/datasources/lib/poller.ts
@@ -161,12 +161,7 @@ export class Poller {
             pendingTargets.map(target =>
                 this.hooks
                     .registerTarget(target)
-                    .then(async request => {
-                        if (request.renewContext) {
-                            await this.initContext(endpoint);
-                        }
-                        target.metricNames = request.metrics;
-                    })
+                    .then(metricNames => (target.metricNames = metricNames))
                     .catch(error => {
                         target.state = PmapiTargetState.ERROR;
                         target.errors.push(error);

--- a/src/datasources/vector/datasource.test.ts
+++ b/src/datasources/vector/datasource.test.ts
@@ -1,0 +1,95 @@
+import { DataSource } from './datasource';
+import { VectorOptions, VectorTargetData } from './types';
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { Target } from '../lib/poller';
+
+jest.mock('../lib/poller');
+jest.mock('../lib/pmapi');
+
+describe('PCP Vector datasource', () => {
+    let instanceSettingsMock: jest.Mocked<DataSourceInstanceSettings<VectorOptions>>;
+    let instance: DataSource;
+    beforeEach(() => {
+        // mocking only relevant properties
+        instanceSettingsMock = {
+            url: '/api/datasources/proxy/2',
+            jsonData: {
+                hostspec: '127.0.0.1',
+                retentionTime: '10m',
+            },
+        } as any;
+        instance = new DataSource(instanceSettingsMock);
+    });
+
+    // anything thats not a metric name
+    it('shouble be able to detect derived metric formulas', () => {
+        const metrics = ['statsd.pmda.received', 'statsd.pmda', 'statsd', 'statsd_pmda', 'statsd_pmda_received'];
+        metrics.forEach(metric => expect(instance.isDerivedMetric(metric)).toBe(false));
+        const formulas = [
+            'disk.all.blktotal/disk.all.total',
+            'disk.all.blktotal+disk.all.total',
+            'disk.all.blktotal-disk.all.total',
+            'disk.all.blktotal*disk.all.total',
+            'network.interface.in.bytes[eth1]',
+            'disk.all.blktotal/2',
+            'disk.all.blktotal+2',
+            'disk.all.blktotal-2',
+            'disk.all.blktotal.2',
+            'avg(network.interface.speed)',
+        ];
+        formulas.forEach(formula => expect(instance.isDerivedMetric(formula)).toBe(true));
+        // empty string, should it ever be passed, is going to be interpreted as derived metric
+        const edgeCase = '';
+        expect(instance.isDerivedMetric(edgeCase)).toBe(true);
+    });
+
+    it('should be able to build derived metric name', () => {
+        const formulas = [
+            'disk.all.blktotal/disk.all.total',
+            'network.interface.in.bytes[eth1]',
+            'disk.all.blktotal/2',
+            'disk.all.blktotal+2',
+        ];
+        const names = formulas.map(formula => {
+            const name = instance.derivedMetricName(formula);
+            expect(name).toContain('derived_');
+            return name;
+        });
+        expect(new Set(names).size).toBe(names.length);
+    });
+
+    it('should be able to create derived metric and store information about it', async () => {
+        const spy = jest
+            .spyOn(instance.state.pmApi, 'createDerived')
+            .mockImplementation(() => Promise.resolve({ success: true }));
+        const expr = 'disk.all.blktotal/2';
+        const targetMock: jest.Mocked<Target<VectorTargetData>> = { query: { expr } } as any;
+        await instance.registerDerivedMetric(targetMock);
+        expect(spy).toBeCalledTimes(1);
+        expect(spy.mock.calls[0][2]).toBe(instance.derivedMetricName(expr));
+        expect(instance.state.derivedMetrics.has(expr)).toBe(true);
+    });
+
+    it('should request context renewal on registration of derived metric', async () => {
+        const expr = 'disk.all.blktotal/2';
+        const metricName = instance.derivedMetricName(expr);
+        const createDerivedSpy = jest
+            .spyOn(instance.state.pmApi, 'createDerived')
+            .mockImplementation(() => Promise.resolve({ success: true }));
+        const registerDeriverMetricSpy = jest.spyOn(instance, 'registerDerivedMetric');
+        const targetMock: jest.Mocked<Target<VectorTargetData>> = { query: { expr } } as any;
+        const resultRegistered = await instance.registerTarget(targetMock);
+        expect(resultRegistered).toEqual({ metrics: [metricName], renewContext: true });
+        expect(createDerivedSpy).toBeCalledTimes(1);
+        expect(registerDeriverMetricSpy).toBeCalledTimes(1);
+        expect(instance.state.derivedMetrics.size).toBe(1);
+        expect(instance.state.derivedMetrics.has(expr)).toBe(true);
+        // will skip registering derived metric, since we already did so
+        const resultRegistrationSkipped = await instance.registerTarget(targetMock);
+        expect(resultRegistrationSkipped).toEqual({ metrics: [metricName] });
+        expect(createDerivedSpy).toBeCalledTimes(1);
+        expect(registerDeriverMetricSpy).toBeCalledTimes(1);
+        expect(instance.state.derivedMetrics.size).toBe(1);
+        expect(instance.state.derivedMetrics.has(expr)).toBe(true);
+    });
+});

--- a/src/datasources/vector/datasource.test.ts
+++ b/src/datasources/vector/datasource.test.ts
@@ -1,7 +1,7 @@
 import { DataSource } from './datasource';
 import { VectorOptions, VectorTargetData } from './types';
 import { DataSourceInstanceSettings } from '@grafana/data';
-import { Target } from '../lib/poller';
+import { PmapiTarget } from '../lib/models/pmapi';
 
 jest.mock('../lib/poller');
 jest.mock('../lib/pmapi');
@@ -63,7 +63,7 @@ describe('PCP Vector datasource', () => {
             .spyOn(instance.state.pmApi, 'createDerived')
             .mockImplementation(() => Promise.resolve({ success: true }));
         const expr = 'disk.all.blktotal/2';
-        const targetMock: jest.Mocked<Target<VectorTargetData>> = { query: { expr } } as any;
+        const targetMock: jest.Mocked<PmapiTarget<VectorTargetData>> = { query: { expr } } as any;
         await instance.registerDerivedMetric(targetMock);
         expect(spy).toBeCalledTimes(1);
         expect(spy.mock.calls[0][2]).toBe(instance.derivedMetricName(expr));
@@ -77,16 +77,16 @@ describe('PCP Vector datasource', () => {
             .spyOn(instance.state.pmApi, 'createDerived')
             .mockImplementation(() => Promise.resolve({ success: true }));
         const registerDeriverMetricSpy = jest.spyOn(instance, 'registerDerivedMetric');
-        const targetMock: jest.Mocked<Target<VectorTargetData>> = { query: { expr } } as any;
+        const targetMock: jest.Mocked<PmapiTarget<VectorTargetData>> = { query: { expr } } as any;
         const resultRegistered = await instance.registerTarget(targetMock);
-        expect(resultRegistered).toEqual({ metrics: [metricName], renewContext: true });
+        expect(resultRegistered).toEqual([metricName]);
         expect(createDerivedSpy).toBeCalledTimes(1);
         expect(registerDeriverMetricSpy).toBeCalledTimes(1);
         expect(instance.state.derivedMetrics.size).toBe(1);
         expect(instance.state.derivedMetrics.has(expr)).toBe(true);
         // will skip registering derived metric, since we already did so
         const resultRegistrationSkipped = await instance.registerTarget(targetMock);
-        expect(resultRegistrationSkipped).toEqual({ metrics: [metricName] });
+        expect(resultRegistrationSkipped).toEqual([metricName]);
         expect(createDerivedSpy).toBeCalledTimes(1);
         expect(registerDeriverMetricSpy).toBeCalledTimes(1);
         expect(instance.state.derivedMetrics.size).toBe(1);

--- a/src/datasources/vector/datasource.ts
+++ b/src/datasources/vector/datasource.ts
@@ -7,21 +7,22 @@ import {
 } from '@grafana/data';
 import { DefaultRequestOptions, QueryResult } from '../lib/models/pcp';
 import { defaults } from 'lodash';
+import md5 from 'blueimp-md5';
 import { interval_to_ms, getDashboardRefreshInterval, getLogger } from '../lib/utils';
-import { Poller, Endpoint } from '../lib/poller';
+import { Poller, Target, Endpoint, QueryResult, RegisterRequest } from '../lib/poller';
 import { PmApi } from '../lib/pmapi';
 import { processTargets } from '../lib/data_processor';
 import * as config from './config';
 import { VectorQuery, VectorOptions, defaultVectorQuery, VectorTargetData } from './types';
 import { buildQueries, testDatasource, metricFindQuery } from '../lib/pmapi_datasource_utils';
 import { getRequestOptions } from '../../lib/utils/api';
-import { CompletePmapiQuery, PmapiTarget } from '../lib/models/pmapi';
 const log = getLogger('datasource');
 
 interface DataSourceState {
     defaultRequestOptions: DefaultRequestOptions;
     pmApi: PmApi;
     poller: Poller;
+    derivedMetrics: Map<string, string>;
 }
 
 export class DataSource extends DataSourceApi<VectorQuery, VectorOptions> {
@@ -50,6 +51,7 @@ export class DataSource extends DataSourceApi<VectorQuery, VectorOptions> {
             defaultRequestOptions,
             pmApi: pmApi,
             poller: poller,
+            derivedMetrics: new Map<string, string>(),
         };
 
         document.addEventListener('visibilitychange', () => {
@@ -61,21 +63,49 @@ export class DataSource extends DataSourceApi<VectorQuery, VectorOptions> {
         return newQuery.expr !== prevQuery.expr;
     }
 
-    isDerivedMetric(expr: string) {
-        // TODO
-        return false;
+    isDerivedMetric(expr: Expr) {
+        /* From: PCPIntro(1)
+         * A node label must begin with an alphabetic character, followed by
+         * zero or more characters drawn from the alphabetics, the digits and
+         * character ``_'' (underscore).  For alphabetic characters in a node
+         * label, upper and lower case are distinguished.
+         *
+         * By convention, the name of a performance metric is constructed by
+         * concatenation of the node labels on a path through the PMNS from the
+         * root node to a leaf node, with a ``.'' as a separator.
+         *
+         * -> Anything that is not a name is considered derived metric expression
+         */
+        return !/^[a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]+)*$/.test(expr);
     }
 
-    async registerTarget(target: PmapiTarget<VectorTargetData>) {
+    derivedMetricName(expr: string): string {
+        return `derived_${md5(expr)}`;
+    }
+
+    async registerDerivedMetric(target: Target<VectorTargetData>): Promise<string[]> {
+        const name = this.derivedMetricName(target.query.expr);
+        const result = await this.state.pmApi.createDerived(this.instanceSettings.url!, target.query.expr, name);
+        if (result.success) {
+            this.state.derivedMetrics.set(target.query.expr, name);
+            return [name];
+        }
+        return [];
+    }
+
+    async registerTarget(target: Target<VectorTargetData>): Promise<RegisterRequest> {
         target.custom = {
             isDerivedMetric: this.isDerivedMetric(target.query.expr),
         };
-
         if (target.custom.isDerivedMetric) {
-            // TOOD: register derived metric
-            return ['derived_hash(target.query.expr)'];
+            const key = this.state.derivedMetrics.get(target.query.expr);
+            if (key) {
+                return { metrics: [key] };
+            }
+            const metrics = await this.registerDerivedMetric(target);
+            return { metrics, renewContext: true };
         } else {
-            return [target.query.expr];
+            return { metrics: [target.query.expr] };
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,6 +2926,11 @@ bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+blueimp-md5@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.17.0.tgz#f4fcac088b115f7b4045f19f5da59e9d01b1bb96"
+  integrity sha512-x5PKJHY5rHQYaADj6NwPUR2QRCUVSggPzrUKkeENpj871o9l9IefJbO2jkT5UvYykeOK9dx0VmkIo6dZ+vThYw==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"


### PR DESCRIPTION
possible future pain points:
- derived metrics cant be "unregistered", related https://github.com/performancecopilot/pcp/issues/1000
- unable to verify semantic correctness of derived metric upon its registration as backend gives generic "metric no defined" error when attempting to fetch with /pmapi/metrics - attempting to fetch mixture of issue-less metrics with ones that are not semantically correct may produce incorrect api responses
- on initial loaded the context may be created more then once if there are queried derived metrics which also request context renewal