### PR TITLE
pmapi: handle semantic and syntax error when attempting to register derived metric

### DIFF
--- a/src/datasources/lib/pmapi.ts
+++ b/src/datasources/lib/pmapi.ts
@@ -51,6 +51,14 @@ export class MetricSemanticError extends Error {
     }
 }
 
+export class MetricSyntaxError extends Error {
+    constructor(readonly expr: string, message?: string) {
+        super(message ?? `Syntax error in '${expr}' definition.`);
+        this.expr = expr;
+        Object.setPrototypeOf(this, MetricSyntaxError.prototype);
+    }
+}
+
 export class DuplicateDerivedMetricNameError extends Error {
     constructor(readonly metric: string, message?: string) {
         super(message ?? `Duplicate derived metric name ${metric}`);
@@ -182,6 +190,8 @@ export class PmApi {
                 return { success: true };
             } else if (has(error, 'data.message') && error.data.message.includes('Semantic Error')) {
                 throw new MetricSemanticError(expr);
+            } else if (has(error, 'data.message') && error.data.message.includes('Syntax Error')) {
+                throw new MetricSyntaxError(expr);
             } else {
                 throw error;
             }

--- a/src/datasources/lib/pmapi.ts
+++ b/src/datasources/lib/pmapi.ts
@@ -43,6 +43,14 @@ export class MetricNotFoundError extends Error {
     }
 }
 
+export class MetricSemanticError extends Error {
+    constructor(readonly expr: string, message?: string) {
+        super(message ?? `Semantic error in '${expr}' definition.`);
+        this.expr = expr;
+        Object.setPrototypeOf(this, MetricSemanticError.prototype);
+    }
+}
+
 export class DuplicateDerivedMetricNameError extends Error {
     constructor(readonly metric: string, message?: string) {
         super(message ?? `Duplicate derived metric name ${metric}`);
@@ -172,6 +180,8 @@ export class PmApi {
         } catch (error) {
             if (has(error, 'data.message') && error.data.message.includes('Duplicate derived metric name')) {
                 return { success: true };
+            } else if (has(error, 'data.message') && error.data.message.includes('Semantic Error')) {
+                throw new MetricSemanticError(expr);
             } else {
                 throw error;
             }


### PR DESCRIPTION
Bubbles semantic and syntax errors in derived metric expressions to the UI.