### PR TITLE
Quickstart page edits

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,19 +3,24 @@ Quickstart
 
 .. include:: refs.rst
 
-Installation (Fedora)
----------------------
+Installation
+------------
+
+Please see :doc:`Installation Guide <installation>`. There is a simple method using
+package manager for Redhat-based distributions, Otherwise it can be installed from source, or
+pre-built plugin bundle from the project's github releases page, or as a container.
+
+Make sure to restart Grafana server and pmproxy after installation the plugin. Eg.
 
 .. code-block:: console
 
-    $ sudo dnf install grafana-pcp
     $ sudo systemctl restart grafana-server
     $ sudo systemctl start pmproxy
 
-For other distributions, please refer to the :doc:`Installation Guide <installation>`.
+Installation is not totally finished until you also enable the Performance Co-Pilot plugin via
+the Grafana Admin user's configuration.
 
-After Grafana and grafana-pcp are installed, you can enable the plugin:
-Open the Grafana configuration, go to Plugins, select *Performance Co-Pilot*, and click the *Enable* button.
+Open the Grafana configuration, go to Plugins, optionally select "Applications" (not Datasources) to filter to it quickly, select *Performance Co-Pilot* and click the *Enable* button on it's page. This will make the PCP datasources and some dashboards available.
 
 Data Sources
 ------------
@@ -27,11 +32,11 @@ Open the Grafana configuration, go to Data Sources and add the
 :doc:`datasources/bpftrace` datasources.
 
 The only required configuration field for each data source is the URL to `pmproxy`_.
-In most cases, the default setting of ``http://localhost:44322`` can be used.
+In most cases the default Redis URL of ``http://localhost:44322`` can be used.
 All other fields can be left to their default values.
 
 .. note::
-   Make sure the URL text box actually contains a value (font color should be white) and not the placeholder value (light grey text).
+   Make sure the *URL* text box actually contains a value (font color should be white) and you're not just looking at the placeholder value (light grey text).
 
 .. note::
    The Redis and bpftrace data sources need additional configuration on the collector host.


### PR DESCRIPTION
The edit suggestions in this PR are to avoid two pitfalls:
* Not seeing the dedicated installation page, which includes the non-redhat-package-manager methods.
* Some gotchas with Grafana's configuration pages that can lead you away from enabling the PCP plugin.