### PR TITLE
redis: send HTTP POST request for long query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **redis**: use LRU cache for series metadata
 - **redis**: fix label_names() function to return all label names if no parameter is specified (now the label name auto-completion in the query editor works again)
 - **redis**: remove deprecated `label_values(metric, label)` function
+- **redis**: fix network error for metrics with many series
 - **bpftrace**: disable scrolling beyond last line in query editor
 - **checklist**: fix dashboard link in navigation bar
 - **chore**: upgrade Grafana dependencies to version 8.4.1


### PR DESCRIPTION
This fixes a network error when retrieving metrics with many series.