### PR TITLE
update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
-    - name: Setup Node.js 17
-      uses: actions/setup-node@v3
+    - name: Setup Go
+      uses: actions/setup-go@v6
       with:
-        node-version: 17
+        go-version-file: 'go.mod'
+
+    - name: Setup Node.js 24
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
 
     - name: Install jsonnet, jsonnet-bundler and grafana/plugin-validator
       run: |


### PR DESCRIPTION
The release workflow needs to be updated to use the correct node version (24) and go version from the go.mod file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline toolchain versions and configuration, including updated checkout actions and modified build environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->