### PR TITLE
Bump dependencies and update Changelog for release

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 # .coderabbit.yaml
+inheritance: true
 reviews:
   auto_review:
     enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 
-## Next Release
+## 6.0.1 (2026-05-20)
 
 * **dashboards**: Fix troubleshooting panel breaking the PCP Vector Checklist dashboard
+* **build**: update node dependencies
 
 ## 6.0.0 (2026-04-30)
 

--- a/package.json
+++ b/package.json
@@ -120,13 +120,15 @@
     "serialize-javascript": "^7.0.5",
     "picomatch": "^4.0.4",
     "protocol-buffers-schema": "^3.6.1",
-    "brace-expansion": "^5.0.5",
+    "brace-expansion": "^5.0.6",
     "uuid": "^14.0.0",
     "postcss": "^8.5.10",
     "yaml": "^1.10.3",
     "@tootallnate/once": "^3.0.1",
     "lodash": "^4.18.0",
-    "dompurify": "^3.4.0"
+    "dompurify": "^3.4.0",
+    "fast-uri": "^3.1.2",
+    "ip-address": "^10.1.1"
   },
   "engines": {
     "node": ">=24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4009,12 +4009,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 
@@ -5937,10 +5937,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+"fast-uri@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 
@@ -6871,10 +6871,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dependabot found a few dependencies that should be updated to resolve vulnerabilities. The 6.0.0 release of grafana-pcp introduced a regression where the PCP Vector Checklist dashboard no longer works. A fix has been merged and the Changelog is updated in this PR for a bugfix release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Version 6.0.1 (2026-05-20) officially released with updated changelog

* **Bug Fixes**
  * Fixed dashboards troubleshooting panel issue

* **Chores**
  * Updated node dependency resolutions to address security/stability
  * Enabled inheritance in CI/configuration settings for review tooling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/performancecopilot/grafana-pcp/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->