### PR TITLE
Add provisioning files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **ci**: bump playwright version to fix hanging ci runs
 * **build**: update node dependencies
+* **misc**: Add provisioning files
 
 ## 6.0.1 (2026-05-20)
 

--- a/provisioning/dashboards/dashboards.yaml
+++ b/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,32 @@
+apiVersion: 1
+
+providers:
+  - name: PCP Vector
+    orgId: 1
+    folder: PCP Vector
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/plugins/performancecopilot-pcp-app/datasources/vector/dashboards
+
+  - name: PCP Valkey
+    orgId: 1
+    folder: PCP Valkey
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/plugins/performancecopilot-pcp-app/datasources/valkey/dashboards
+
+  - name: PCP bpftrace
+    orgId: 1
+    folder: PCP bpftrace
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/plugins/performancecopilot-pcp-app/datasources/bpftrace/dashboards

--- a/provisioning/datasources/datasource.yaml
+++ b/provisioning/datasources/datasource.yaml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+datasources:
+  - name: PCP Vector
+    type: performancecopilot-vector-datasource
+    access: proxy
+    url: http://localhost:44322
+    isDefault: true
+    jsonData:
+      hostspec: ''
+      retentionTime: '5m'
+
+  - name: PCP Valkey
+    type: performancecopilot-valkey-datasource
+    access: proxy
+    url: http://localhost:44322
+
+  - name: PCP bpftrace
+    type: performancecopilot-bpftrace-datasource
+    access: proxy
+    url: http://localhost:44322
+    jsonData:
+      hostspec: ''
+      retentionTime: '5m'

--- a/provisioning/plugins/plugins.yaml
+++ b/provisioning/plugins/plugins.yaml
@@ -1,0 +1,5 @@
+apiVersion: 1
+
+apps:
+  - type: performancecopilot-pcp-app
+    disabled: false


### PR DESCRIPTION
I'm hoping to make a new submission to the grafana plugin catalog for grafana-pcp. This has not happened in some time so work needs to be done on the plugin. The addition of the provisioning files moves the grafana-pcp plugin closer to following the best practices for grafana plugins. These files should help the eventual reviewers with setting up and testing the plugin.