### PR TITLE
Transition to using built in grafana flame graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * **config**: Update appconfig to be in line with plugin best practices
 * **queries**: Add default queries for the datasources
 * **vector, bpftrace**: Replace legacy CSS classes with @grafana/ui FieldSet in config editors
+* **dashboards**: Bundled flame graph dashboards now use the built-in grafana flame graph visualization instead of the PCP Flame Graph panel plugin.
+* **flame graphs**: PCP Flame Graph panel plugin will be removed in future releases. Users should start using the built-in grafana flame graphs instead and transition any custom dashboards to use this visualization.
 
 ## 6.0.1 (2026-05-20)
 

--- a/src/datasources/bpftrace/components/BPFtraceQueryEditor.tsx
+++ b/src/datasources/bpftrace/components/BPFtraceQueryEditor.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { defaultsDeep } from 'lodash';
 import React, { PureComponent } from 'react';
 import { QueryEditorProps } from '@grafana/data';
-import { Combobox, InlineField, InlineFieldRow, Input } from '@grafana/ui';
+import { Combobox, InlineField, InlineFieldRow, InlineSwitch, Input } from '@grafana/ui';
 import { isBlank } from '../../../common/utils';
 import { Monaco } from '../../../components/monaco';
 import { MonacoEditorLazy } from '../../../components/monaco/MonacoEditorLazy';
@@ -26,6 +26,9 @@ interface State {
     legendFormat?: string;
     url?: string;
     hostspec?: string;
+    flamegraphMinSamples: number;
+    flamegraphHideUnresolved: boolean;
+    flamegraphHideIdle: boolean;
 }
 
 export class BPFtraceQueryEditor extends PureComponent<Props, State> {
@@ -43,6 +46,9 @@ export class BPFtraceQueryEditor extends PureComponent<Props, State> {
             legendFormat: query.legendFormat,
             url: query.url,
             hostspec: query.hostspec,
+            flamegraphMinSamples: query.flamegraphMinSamples ?? 1,
+            flamegraphHideUnresolved: query.flamegraphHideUnresolved ?? false,
+            flamegraphHideIdle: query.flamegraphHideIdle ?? false,
         };
         this.editorOptions = {
             lineNumbers: 'on',
@@ -74,8 +80,22 @@ export class BPFtraceQueryEditor extends PureComponent<Props, State> {
         this.setState({ hostspec }, this.runQuery);
     };
 
+    onFlamegraphMinSamplesChange = (event: React.SyntheticEvent<HTMLInputElement>) => {
+        const n = parseInt(event.currentTarget.value, 10);
+        const flamegraphMinSamples = Math.max(1, Number.isFinite(n) ? n : 1);
+        this.setState({ flamegraphMinSamples }, this.runQuery);
+    };
+
+    onFlamegraphHideUnresolvedChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ flamegraphHideUnresolved: event.currentTarget.checked }, this.runQuery);
+    };
+
+    onFlamegraphHideIdleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ flamegraphHideIdle: event.currentTarget.checked }, this.runQuery);
+    };
+
     getQuery = (): BPFtraceQuery => {
-        return {
+        const query: BPFtraceQuery = {
             refId: this.props.query.refId,
             expr: this.state.expr,
             format: this.state.format,
@@ -83,6 +103,12 @@ export class BPFtraceQueryEditor extends PureComponent<Props, State> {
             url: this.state.url,
             hostspec: this.state.hostspec,
         };
+        if (this.state.format === TargetFormat.FlameGraph) {
+            query.flamegraphMinSamples = this.state.flamegraphMinSamples;
+            query.flamegraphHideUnresolved = this.state.flamegraphHideUnresolved;
+            query.flamegraphHideIdle = this.state.flamegraphHideIdle;
+        }
+        return query;
     };
 
     runQuery = () => {
@@ -161,7 +187,7 @@ export class BPFtraceQueryEditor extends PureComponent<Props, State> {
                     <InlineField
                         label="Host specification"
                         tooltip="Override the host specification for this panel. Useful for monitoring remote hosts."
-                        labelWidth={18}
+                        labelWidth={20}
                     >
                         <Input
                             placeholder="override host specification"
@@ -171,6 +197,34 @@ export class BPFtraceQueryEditor extends PureComponent<Props, State> {
                         />
                     </InlineField>
                 </InlineFieldRow>
+
+                {this.state.format === TargetFormat.FlameGraph && (
+                    <InlineFieldRow>
+                        <InlineField label="Min samples" tooltip="Minimum number of samples for a stack to be shown">
+                            <Input
+                                type="number"
+                                value={this.state.flamegraphMinSamples}
+                                onChange={this.onFlamegraphMinSamplesChange}
+                                onBlur={this.runQuery}
+                                width={8}
+                            />
+                        </InlineField>
+
+                        <InlineField label="Hide unresolved" tooltip="Hide stack frames starting with 0x">
+                            <InlineSwitch
+                                value={this.state.flamegraphHideUnresolved}
+                                onChange={this.onFlamegraphHideUnresolvedChange}
+                            />
+                        </InlineField>
+
+                        <InlineField label="Hide idle" tooltip="Hide idle CPU stacks (cpuidle_enter_state)">
+                            <InlineSwitch
+                                value={this.state.flamegraphHideIdle}
+                                onChange={this.onFlamegraphHideIdleChange}
+                            />
+                        </InlineField>
+                    </InlineFieldRow>
+                )}
             </div>
         );
     }

--- a/src/datasources/bpftrace/dashboards/pcp-bpftrace-flame-graphs.jsonnet
+++ b/src/datasources/bpftrace/dashboards/pcp-bpftrace-flame-graphs.jsonnet
@@ -5,8 +5,9 @@ local flameGraph(
   datasource=null,
       ) = {
   title: title,
-  type: 'performancecopilot-flamegraph-panel',
+  type: 'flamegraph',
   datasource: datasource,
+  options: {},
 
   _nextTarget:: 0,
   addTarget(target):: self {
@@ -50,7 +51,7 @@ grafana.dashboard.new(
     x: 0,
     y: 0,
     w: 24,
-    h: 2,
+    h: 3,
   }
 )
 .addPanel(
@@ -68,7 +69,7 @@ grafana.dashboard.new(
     { expr: 'kernel.cpu.util.sys', format: 'time_series' },
   ]), gridPos={
     x: 0,
-    y: 2,
+    y: 3,
     w: 24,
     h: 4,
   }
@@ -79,10 +80,10 @@ grafana.dashboard.new(
     datasource='$bpftrace_datasource',
   )
   .addTargets([
-    { expr: importstr 'tools/kstacks.bt', format: 'flamegraph' },
+    { expr: importstr 'tools/kstacks.bt', format: 'flamegraph_grafana' },
   ]), gridPos={
     x: 0,
-    y: 6,
+    y: 7,
     w: 24,
     h: 8,
   }
@@ -93,13 +94,13 @@ grafana.dashboard.new(
     datasource='$bpftrace_datasource',
   )
   .addTargets([
-    { expr: importstr 'tools/ustacks.bt', format: 'flamegraph' },
+    { expr: importstr 'tools/ustacks.bt', format: 'flamegraph_grafana' },
   ]), gridPos={
     x: 0,
-    y: 14,
+    y: 15,
     w: 24,
     h: 8,
   }
 ) + {
-  revision: 3,
+  revision: 1,
 }

--- a/src/datasources/bpftrace/script_manager.ts
+++ b/src/datasources/bpftrace/script_manager.ts
@@ -36,7 +36,7 @@ export class ScriptManager {
                 throw new GenericError('Please printf() a table in CSV format in the BPFtrace script.');
             }
             return [foundVar[0]];
-        } else if (format === TargetFormat.FlameGraph) {
+        } else if (format === TargetFormat.FlameGraphLegacy || format === TargetFormat.FlameGraph) {
             const foundVar = Object.entries(script.variables).find(
                 ([, varDef]) => varDef.metrictype === MetricType.Stacks
             );

--- a/src/datasources/bpftrace/types.ts
+++ b/src/datasources/bpftrace/types.ts
@@ -5,7 +5,11 @@ import { Script } from './script';
 
 export interface BPFtraceOptions extends PmapiOptions {}
 
-export interface BPFtraceQuery extends MinimalPmapiQuery {}
+export interface BPFtraceQuery extends MinimalPmapiQuery {
+    flamegraphMinSamples?: number;
+    flamegraphHideUnresolved?: boolean;
+    flamegraphHideIdle?: boolean;
+}
 
 export const defaultBPFtraceQuery: BPFtraceQuery & Optional<PmapiQuery, 'url' | 'hostspec'> = {
     refId: 'A',

--- a/src/datasources/lib/pmapi/data_processor.test.ts
+++ b/src/datasources/lib/pmapi/data_processor.test.ts
@@ -1,3 +1,4 @@
+import { MISSING_VALUE } from '@grafana/data';
 import { grafana, pcp, poller } from '../specs/fixtures';
 import { TargetFormat } from '../types';
 import { processQueries } from './data_processor';
@@ -326,6 +327,122 @@ describe('data processor', () => {
             }
         `
         );
+    });
+
+    it('should transform to Grafana flamegraph nested set format', () => {
+        const target = poller.target({
+            query: { expr: 'bpftrace.scripts.test.data.root', refId: 'A', format: TargetFormat.FlameGraph },
+        });
+
+        const metric = {
+            metadata: pcp.metadata({
+                name: 'bpftrace.scripts.test.data.root',
+                type: 'u64',
+                sem: 'instant' as any,
+                units: 'count',
+            }),
+            values: [
+                {
+                    timestampMs: 10000,
+                    values: [
+                        { instance: 0, value: 5 },
+                        { instance: 1, value: 3 },
+                        { instance: 2, value: 4 },
+                    ],
+                },
+            ],
+            instanceDomain: {
+                instances: {
+                    0: { instance: 0, name: '\n    write+24\n    do_syscall_64\n', labels: {} },
+                    1: { instance: 1, name: '\n    read+24\n    do_syscall_64\n', labels: {} },
+                    2: { instance: 2, name: '\n    write+24\n    __x64_sys_write\n', labels: {} },
+                },
+                labels: {},
+            },
+        };
+
+        const endpoint = poller.endpoint({ metrics: [metric], targets: [target] });
+        const dataQueryRequest = grafana.dataQueryRequest({ targets: [target.query] });
+
+        const result = processQueries(dataQueryRequest, [{ endpoint, query: target.query, metrics: [metric] }], 1);
+        expect(result).toHaveLength(1);
+
+        const frame = result[0];
+        expect(frame.meta?.preferredVisualisationType).toBe('flamegraph');
+        expect(frame.fields).toHaveLength(4);
+
+        const levels = frame.fields[0].values;
+        const labels = frame.fields[1].values;
+        const values = frame.fields[2].values;
+        const selfs = frame.fields[3].values;
+
+        expect(labels[0]).toBe('root');
+        expect(levels[0]).toBe(0);
+        expect(values[0]).toBe(12); // 5 + 3 + 4
+        expect(selfs[0]).toBe(0);
+
+        // write+24 appears under two parents (do_syscall_64 and __x64_sys_write)
+        // but at level 1 there should be write+24 with cumulative value 9 (5+4), read+24 with 3
+        const level1Labels = labels.filter((_: string, i: number) => levels[i] === 1);
+        expect(level1Labels).toContain('write+24');
+        expect(level1Labels).toContain('read+24');
+    });
+
+    it('should apply flamegraph filtering options', () => {
+        const target = poller.target({
+            query: {
+                expr: 'bpftrace.scripts.test.data.root',
+                refId: 'A',
+                format: TargetFormat.FlameGraph,
+                flamegraphMinSamples: 4,
+                flamegraphHideUnresolved: true,
+                flamegraphHideIdle: false,
+            } as any,
+        });
+
+        const metric = {
+            metadata: pcp.metadata({
+                name: 'bpftrace.scripts.test.data.root',
+                type: 'u64',
+                sem: 'instant' as any,
+                units: 'count',
+            }),
+            values: [
+                {
+                    timestampMs: 10000,
+                    values: [
+                        { instance: 0, value: 5 },
+                        { instance: 1, value: 2 },
+                        { instance: 2, value: 6 },
+                    ],
+                },
+            ],
+            instanceDomain: {
+                instances: {
+                    0: { instance: 0, name: '\n    write+24\n', labels: {} },
+                    1: { instance: 1, name: '\n    read+24\n', labels: {} },
+                    2: { instance: 2, name: '\n    0xdeadbeef\n    write+24\n', labels: {} },
+                },
+                labels: {},
+            },
+        };
+
+        const endpoint = poller.endpoint({ metrics: [metric], targets: [target] });
+        const dataQueryRequest = grafana.dataQueryRequest({ targets: [target.query] });
+
+        const result = processQueries(dataQueryRequest, [{ endpoint, query: target.query, metrics: [metric] }], 1);
+        const labels = result[0].fields[1].values;
+        const values = result[0].fields[2].values;
+
+        // read+24 has value 2, below minSamples of 4 — should be filtered out
+        expect(labels).not.toContain('read+24');
+        // 0xdeadbeef should be filtered out (hideUnresolved)
+        expect(labels).not.toContain('0xdeadbeef');
+        // write+24 should still appear — instance 2's 0xdeadbeef is skipped, leaving write+24 as the leaf
+        // both instances (5 + 6) accumulate at the same node
+        expect(labels).toContain('write+24');
+        const writeIdx = labels.indexOf('write+24');
+        expect(values[writeIdx]).toBe(11);
     });
 
     it('should process a CSV table', () => {

--- a/src/datasources/lib/pmapi/data_processor.ts
+++ b/src/datasources/lib/pmapi/data_processor.ts
@@ -408,6 +408,118 @@ function transformToCsvTable(frames: DataFrame[]) {
     return tableFrame;
 }
 
+interface StackNode {
+    name: string;
+    leafValue: number;
+    children: StackNode[];
+}
+
+function buildStackTree(
+    frames: MutableDataFrame[],
+    minSamples: number,
+    hideUnresolved: boolean,
+    hideIdle: boolean
+): StackNode {
+    const root: StackNode = { name: 'root', leafValue: 0, children: [] };
+
+    for (const frame of frames) {
+        for (const field of frame.fields) {
+            if (field.type !== FieldType.number || !field.config.custom?.instance?.name) {
+                continue;
+            }
+
+            let count = 0;
+            for (let i = 0; i < field.values.length; i++) {
+                const value = field.values[i];
+                if (value !== MISSING_VALUE) {
+                    count += value;
+                }
+            }
+            if (count < minSamples) {
+                continue;
+            }
+
+            const instanceName: string = field.config.custom.instance.name;
+            let curNode = root;
+            const stacks = instanceName.split(/[\n,]/);
+            let skip = false;
+            for (let stackFrame of stacks) {
+                stackFrame = stackFrame.trim();
+                if (!stackFrame || (hideUnresolved && stackFrame.startsWith('0x'))) {
+                    continue;
+                }
+                if (hideIdle && stackFrame.startsWith('cpuidle_enter_state+')) {
+                    skip = true;
+                    break;
+                }
+                let child = curNode.children.find(c => c.name === stackFrame);
+                if (!child) {
+                    child = { name: stackFrame, leafValue: 0, children: [] };
+                    curNode.children.push(child);
+                }
+                curNode = child;
+            }
+            if (!skip) {
+                curNode.leafValue += count;
+            }
+        }
+    }
+    return root;
+}
+
+function computeCumulativeValue(node: StackNode): number {
+    let total = node.leafValue;
+    for (const child of node.children) {
+        total += computeCumulativeValue(child);
+    }
+    return total;
+}
+
+function flattenTree(
+    node: StackNode,
+    level: number,
+    levels: number[],
+    labels: string[],
+    values: number[],
+    selfs: number[]
+) {
+    const cumulative = computeCumulativeValue(node);
+    levels.push(level);
+    labels.push(node.name);
+    values.push(cumulative);
+    selfs.push(node.leafValue);
+    for (const child of node.children) {
+        flattenTree(child, level + 1, levels, labels, values, selfs);
+    }
+}
+
+function transformToFlameGraph(frames: MutableDataFrame[], query: PmapiQuery): MutableDataFrame {
+    const minSamples = (query as any).flamegraphMinSamples ?? 1;
+    const hideUnresolved = (query as any).flamegraphHideUnresolved ?? false;
+    const hideIdle = (query as any).flamegraphHideIdle ?? false;
+
+    const root = buildStackTree(frames, minSamples, hideUnresolved, hideIdle);
+
+    const levels: number[] = [];
+    const labels: string[] = [];
+    const values: number[] = [];
+    const selfs: number[] = [];
+    flattenTree(root, 0, levels, labels, values, selfs);
+
+    const flameFrame = new MutableDataFrame({
+        fields: [
+            { name: 'level', type: FieldType.number, values: levels },
+            { name: 'label', type: FieldType.string, values: labels },
+            { name: 'value', type: FieldType.number, values: values },
+            { name: 'self', type: FieldType.number, values: selfs },
+        ],
+        meta: {
+            preferredVisualisationType: 'flamegraph',
+        },
+    });
+    return flameFrame;
+}
+
 export function processQueries(
     request: DataQueryRequest<MinimalPmapiQuery>,
     queryResults: QueryResult[],
@@ -432,8 +544,10 @@ export function processQueries(
 
     switch (format) {
         case TargetFormat.TimeSeries:
-        case TargetFormat.FlameGraph:
+        case TargetFormat.FlameGraphLegacy:
             return frames;
+        case TargetFormat.FlameGraph:
+            return [transformToFlameGraph(frames, queryResults[0].query)];
         case TargetFormat.Heatmap:
             frames.forEach(transformToHeatMap);
             return frames;

--- a/src/datasources/lib/pmapi/field_transformations.ts
+++ b/src/datasources/lib/pmapi/field_transformations.ts
@@ -76,7 +76,7 @@ const PCP_TIME_UNITS: Dict<string, number> = {
 
 export function applyFieldTransformations(query: PmapiQuery, metadata: Metadata, frame: MutableDataFrame): void {
     if (metadata.sem === Semantics.Counter) {
-        const discreteValues = query.format === TargetFormat.FlameGraph;
+        const discreteValues = query.format === TargetFormat.FlameGraphLegacy || query.format === TargetFormat.FlameGraph;
         if (query.options.rateConversion) {
             rateConversion(frame, discreteValues);
         }

--- a/src/datasources/lib/types.ts
+++ b/src/datasources/lib/types.ts
@@ -7,6 +7,8 @@ export enum TargetFormat {
     MetricsTable = 'metrics_table',
     /** bpftrace only */
     CsvTable = 'csv_table',
-    /** bpftrace only */
-    FlameGraph = 'flamegraph',
+    /** bpftrace only — deprecated, use FlameGraph instead */
+    FlameGraphLegacy = 'flamegraph',
+    /** bpftrace only — outputs nested set DataFrame for Grafana's built-in flamegraph visualization */
+    FlameGraph = 'flamegraph_grafana',
 }

--- a/src/panels/flamegraph/plugin.json
+++ b/src/panels/flamegraph/plugin.json
@@ -1,9 +1,9 @@
 {
     "type": "panel",
-    "name": "PCP Flame Graph",
+    "name": "PCP Flame Graph (Deprecated)",
     "id": "performancecopilot-flamegraph-panel",
     "info": {
-        "description": "Grafana Panel for displaying Flame Graphs",
+        "description": "Deprecated: use Grafana's built-in Flame Graph panel with the 'Flame Graph' format instead. This panel will be removed in a future release.",
         "logos": {
             "small": "img/flamegraph.svg",
             "large": "img/flamegraph.svg"


### PR DESCRIPTION
The old grafana-pcp flame graph panel plugin used angular and was introduced back when grafana did not have a built in flame graph visualization. Now that grafana has support for flame graphs, and angular plugins are being deprecated, we should transition to using the built in grafana flame graphs and drop the grafana-pcp flame graph panel plugin. I did not remove support for the old flame graphs so any existing custom dashboards using this panel type will not break. The bundled dashboards with flame graphs now use the grafana built in flame graphs. Additionally, the old flame graph data format in the bpftrace query editor has been removed.