### PR TITLE
Geomaps: add error when longitude/latitude labels are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * **vector, bpftrace**: Replace legacy CSS classes with @grafana/ui FieldSet in config editors
 * **dashboards**: Bundled flame graph dashboards now use the built-in grafana flame graph visualization instead of the PCP Flame Graph panel plugin.
 * **flame graphs**: PCP Flame Graph panel plugin will be removed in future releases. Users should start using the built-in grafana flame graphs instead and transition any custom dashboards to use this visualization.
+* **geomaps**: Add clear error when longitude and latitude labels are missing
 
 ## 6.0.1 (2026-05-20)
 

--- a/pkg/datasources/valkey/data_processor.go
+++ b/pkg/datasources/valkey/data_processor.go
@@ -401,15 +401,23 @@ func (ds *valkeyDatasourceInstance) transformToGeoMap(frames *data.Frames) error
 			valFloat, _ := field.FloatAt(field.Len() - 1)
 			valueField.Append(&valFloat)
 
-			//collect and append the longitude field
-			longitude, err := convertFieldValue("float", field.Labels["longitude"])
+			longitudeLabel := field.Labels["longitude"]
+			latitudeLabel := field.Labels["latitude"]
+			if longitudeLabel == "" || latitudeLabel == "" {
+				return fmt.Errorf(
+					"metric %q is missing geolocation labels (longitude=%q, latitude=%q): "+
+						"ensure PCP geolocation labels are configured, e.g. in /etc/pcp/labels/optional/geolocate",
+					field.Name, longitudeLabel, latitudeLabel,
+				)
+			}
+
+			longitude, err := convertFieldValue("float", longitudeLabel)
 			if err != nil {
 				return err
 			}
 			longitudeField.Append(longitude)
 
-			//collect and append the latitude field
-			latitude, err := convertFieldValue("float", field.Labels["latitude"])
+			latitude, err := convertFieldValue("float", latitudeLabel)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Currrently, geomaps do not provide a clear error message when longitude and latitude labels are missing. With this change, a clear error will be displayed if the labels are missing