### PR TITLE
bump grafana/plugin-e2e version to fix failing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@axe-core/playwright": "^4.11.1",
     "@grafana/data": "12.4.2",
     "@grafana/eslint-config": "^9.0.0",
-    "@grafana/plugin-e2e": "^3.4.2",
+    "@grafana/plugin-e2e": "^3.9.2",
     "@grafana/runtime": "12.4.2",
     "@grafana/tsconfig": "^2.0.1",
     "@grafana/ui": "12.4.2",

--- a/tests/datasources/valkey.spec.ts
+++ b/tests/datasources/valkey.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@grafana/plugin-e2e';
+import { test, expect, DashboardPage } from '@grafana/plugin-e2e';
 
 test.describe('PCP Valkey data source', () => {
   test('should import bundled dashboards', async ({ createDataSourceConfigPage, page }) => {
@@ -11,47 +11,21 @@ test.describe('PCP Valkey data source', () => {
     await expect(page.getByText(/[Dd]ashboard [Ii]mported/)).toBeVisible();
   });
 
-  test('should auto-complete metric names', async ({ createDataSourceConfigPage, page }) => {
+  test('should auto-complete metric names', async ({
+    createDataSourceConfigPage,
+    page,
+    selectors,
+    grafanaVersion,
+    request,
+  }, testInfo) => {
     const configPage = await createDataSourceConfigPage({ type: 'performancecopilot-valkey-datasource' });
     await page.getByPlaceholder('http://localhost:44322').fill('http://localhost:44322');
     await expect(configPage.saveAndTest()).toBeOK();
 
-    await page.goto(`/dashboard/new-with-ds/${configPage.datasource.uid}`);
-    await page.waitForLoadState('networkidle');
-
-    // Close any dialogs that might be blocking
-    const closeButton = page.getByRole('button', { name: 'Close' });
-    try {
-      if (await closeButton.isVisible({ timeout: 1000 })) {
-        await closeButton.click();
-        await page.waitForTimeout(500);
-      }
-    } catch {
-      // No dialog present
-    }
-
-    // Grafana 13 changed the UI - try new sidebar "add panel" button first, fall back to Grafana 12
-    const addPanelGrafana13 = page.getByTestId('data-testid sidebar add new panel');
-    const addVisualizationButton = page.getByRole('button', { name: 'Add visualization' });
-
-    if (await addPanelGrafana13.isVisible({ timeout: 2000 }).catch(() => false)) {
-      // Grafana 13: click add panel, then click "Configure visualization", then select datasource
-      await addPanelGrafana13.click();
-      await page.getByRole('button', { name: 'Configure visualization' }).click();
-
-      // Select datasource from dropdown (Grafana 13 uses data-source-card)
-      const datasourcePicker = page.getByTestId('data-testid Select a data source');
-      await datasourcePicker.click();
-
-      // Wait for dropdown to open and datasource card to be visible
-      const datasourceCard = page.getByTestId('data-source-card').filter({ hasText: 'PCP Valkey' }).first();
-      await datasourceCard.waitFor({ state: 'visible' });
-      await datasourceCard.click();
-    } else {
-      // Grafana 12: click "Add visualization", then select datasource
-      await addVisualizationButton.click();
-      await page.getByRole('button', { name: configPage.datasource.name }).click();
-    }
+    const dashboardPage = new DashboardPage({ page, selectors, grafanaVersion, request, testInfo });
+    await dashboardPage.goto();
+    const panelEditPage = await dashboardPage.addPanel();
+    await panelEditPage.datasource.set(configPage.datasource.name);
 
     const editor = page.locator('.monaco-editor textarea');
     await editor.waitFor({ state: 'visible' });

--- a/tests/datasources/vector.spec.ts
+++ b/tests/datasources/vector.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@grafana/plugin-e2e';
+import { test, expect, DashboardPage } from '@grafana/plugin-e2e';
 
 test.describe('PCP Vector data source', () => {
   test('should import bundled dashboards', async ({ createDataSourceConfigPage, page }) => {
@@ -11,47 +11,21 @@ test.describe('PCP Vector data source', () => {
     await expect(page.getByText(/[Dd]ashboard [Ii]mported/)).toBeVisible();
   });
 
-  test('should auto-complete metric names', async ({ createDataSourceConfigPage, page }) => {
+  test('should auto-complete metric names', async ({
+    createDataSourceConfigPage,
+    page,
+    selectors,
+    grafanaVersion,
+    request,
+  }, testInfo) => {
     const configPage = await createDataSourceConfigPage({ type: 'performancecopilot-vector-datasource' });
     await page.getByPlaceholder('http://localhost:44322').fill('http://localhost:44322');
     await expect(configPage.saveAndTest({ path: '/pmapi/context' })).toBeOK();
 
-    await page.goto(`/dashboard/new-with-ds/${configPage.datasource.uid}`);
-    await page.waitForLoadState('networkidle');
-
-    // Close any dialogs that might be blocking
-    const closeButton = page.getByRole('button', { name: 'Close' });
-    try {
-      if (await closeButton.isVisible({ timeout: 1000 })) {
-        await closeButton.click();
-        await page.waitForTimeout(500);
-      }
-    } catch {
-      // No dialog present
-    }
-
-    // Grafana 13 changed the UI - try new sidebar "add panel" button first, fall back to Grafana 12
-    const addPanelGrafana13 = page.getByTestId('data-testid sidebar add new panel');
-    const addVisualizationButton = page.getByRole('button', { name: 'Add visualization' });
-
-    if (await addPanelGrafana13.isVisible({ timeout: 2000 }).catch(() => false)) {
-      // Grafana 13: click add panel, then click "Configure visualization", then select datasource
-      await addPanelGrafana13.click();
-      await page.getByRole('button', { name: 'Configure visualization' }).click();
-
-      // Select datasource from dropdown (Grafana 13 uses data-source-card)
-      const datasourcePicker = page.getByTestId('data-testid Select a data source');
-      await datasourcePicker.click();
-
-      // Wait for dropdown to open and datasource card to be visible
-      const datasourceCard = page.getByTestId('data-source-card').filter({ hasText: 'PCP Vector' }).first();
-      await datasourceCard.waitFor({ state: 'visible' });
-      await datasourceCard.click();
-    } else {
-      // Grafana 12: click "Add visualization", then select datasource
-      await addVisualizationButton.click();
-      await page.getByRole('button', { name: configPage.datasource.name }).click();
-    }
+    const dashboardPage = new DashboardPage({ page, selectors, grafanaVersion, request, testInfo });
+    await dashboardPage.goto();
+    const panelEditPage = await dashboardPage.addPanel();
+    await panelEditPage.datasource.set(configPage.datasource.name);
 
     const editor = page.locator('.monaco-editor textarea');
     await editor.waitFor({ state: 'visible' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,14 +936,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/e2e-selectors@npm:13.0.0-22898798261":
-  version: 13.0.0-22898798261
-  resolution: "@grafana/e2e-selectors@npm:13.0.0-22898798261"
+"@grafana/e2e-selectors@npm:13.1.0-25644485979":
+  version: 13.1.0-25644485979
+  resolution: "@grafana/e2e-selectors@npm:13.1.0-25644485979"
   dependencies:
     semver: "npm:^7.7.0"
     tslib: "npm:2.8.1"
-    typescript: "npm:5.9.2"
-  checksum: 10c0/d437e29cb25e4974088ab9108d0489dd3c9fb599d03b46a480814bcdb36ee62bae6b5cad865137665ae8d1d0a23eb74b9e8cee34f386a5738e68eaddeb53bd36
+    typescript: "npm:6.0.2"
+  checksum: 10c0/4333578ebd1e072a869376e1a31de222ba8678a01cbe6970d27ce483de8954289f08a3f6bdd59bbf6a1fb4f35c08a8a89440b0992bb2e1348eadc648e8a44992
   languageName: node
   linkType: hard
 
@@ -1003,13 +1003,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-e2e@npm:^3.4.2":
-  version: 3.4.5
-  resolution: "@grafana/plugin-e2e@npm:3.4.5"
+"@grafana/plugin-e2e@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@grafana/plugin-e2e@npm:3.9.2"
   dependencies:
-    "@grafana/e2e-selectors": "npm:13.0.0-22898798261"
-    semver: "npm:^7.5.4"
-    uuid: "npm:^13.0.0"
+    "@grafana/e2e-selectors": "npm:13.1.0-25644485979"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@axe-core/playwright": ^4.11.1
@@ -1017,7 +1015,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10c0/f125153cd7ff222e24c418bff805263872d2c0012a24ecf83f00f7b9e0a3369b2283e04a3d234d03c43aec779ce7e6aed9de418ebb9769233589937e02c8760a
+  checksum: 10c0/6dbdf6bd966034ce074835c5816e7d4e483110493875d97907a65b7d0d9229a40ed1601c12e02b6bfacc1c300c8319299c9db50e7a219824721cd80f0b26de40
   languageName: node
   linkType: hard
 
@@ -9054,7 +9052,7 @@ __metadata:
     "@grafana/data": "npm:12.4.2"
     "@grafana/eslint-config": "npm:^9.0.0"
     "@grafana/i18n": "npm:12.4.2"
-    "@grafana/plugin-e2e": "npm:^3.4.2"
+    "@grafana/plugin-e2e": "npm:^3.9.2"
     "@grafana/runtime": "npm:12.4.2"
     "@grafana/schema": "npm:12.4.2"
     "@grafana/tsconfig": "npm:^2.0.1"
@@ -11462,6 +11460,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:6.0.2":
+  version: 6.0.2
+  resolution: "typescript@npm:6.0.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>":
   version: 5.9.2
   resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
@@ -11469,6 +11477,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.2
+  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/49f0b84fc6ca55653e77752b8a61beabc09ee3dae5d965c31596225aa6ef213c5727b1d2e895b900416dc603854ba0872ac4a812c2a4ed6793a601f9c675de02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The grafana/plugin-e2e version needs to be bumped to work with grafana 13+. I also updated the tests to be more version aware rather than manually checking versions.