### PR TITLE
bpftrace: fix dashboard scripts on newer/BTF-enabled kernels

### DIFF
--- a/src/datasources/bpftrace/dashboards/tools/biolatency.bt
+++ b/src/datasources/bpftrace/dashboards/tools/biolatency.bt
@@ -11,14 +11,14 @@
  */
 // include: @usecs
 
-kprobe:blk_account_io_start
+tracepoint:block:block_rq_issue
 {
-	@start[arg0] = nsecs;
+	@start[args->dev, args->sector] = nsecs;
 }
 
-kprobe:blk_account_io_done
-/@start[arg0]/
+tracepoint:block:block_rq_complete
+/@start[args->dev, args->sector]/
 {
-	@usecs = hist((nsecs - @start[arg0]) / 1000);
-	delete(@start[arg0]);
+	@usecs = hist((nsecs - @start[args->dev, args->sector]) / 1000);
+	delete(@start[args->dev, args->sector]);
 }

--- a/src/datasources/bpftrace/dashboards/tools/runqlat.bt
+++ b/src/datasources/bpftrace/dashboards/tools/runqlat.bt
@@ -11,7 +11,15 @@
  */
 // include: @usecs
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/sched.h>
+#else
+/*
+ * With BTF providing types, full headers are not needed.
+ * We only need to supply the preprocessor defines used in this script.
+ */
+#define TASK_RUNNING 0
+#endif
 
 tracepoint:sched:sched_wakeup,
 tracepoint:sched:sched_wakeup_new

--- a/src/datasources/bpftrace/dashboards/tools/runqlen.bt
+++ b/src/datasources/bpftrace/dashboards/tools/runqlen.bt
@@ -10,14 +10,31 @@
  * 07-Oct-2018	Brendan Gregg	Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/sched.h>
+#endif
 
 // Until BTF is available, we'll need to declare some of this struct manually,
 // since it isn't avaible to be #included. This will need maintenance to match
 // your kernel version. It is from kernel/sched/sched.h:
+struct load_weight {
+	unsigned long weight;
+	unsigned int inv_weight;
+};
+
+#ifndef LINUX_VERSION_CODE
+#include <linux/version.h>
+#endif
+#ifndef KERNEL_VERSION
+#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + (c))
+#endif
+
+// runnable_weight was removed from cfs_rq in Linux 5.7.0
 struct cfs_rq_partial {
 	struct load_weight load;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)
 	unsigned long runnable_weight;
+#endif
 	unsigned int nr_running;
 	unsigned int h_nr_running;
 };
@@ -27,6 +44,8 @@ profile:hz:99
 	$task = (struct task_struct *)curtask;
 	$my_q = (struct cfs_rq_partial *)$task->se.cfs_rq;
 	$len = $my_q->nr_running;
-	$len = $len > 0 ? $len - 1 : 0;	// subtract currently runing task
+	if ($len > 0) {
+		$len = (uint32)($len - 1);	// subtract currently running task
+	}
 	@runqlen = lhist($len, 0, 100, 1);
 }

--- a/src/datasources/bpftrace/dashboards/tools/syscall_count.bt
+++ b/src/datasources/bpftrace/dashboards/tools/syscall_count.bt
@@ -1,4 +1,4 @@
-tracepoint:syscalls:sys_enter_open, tracepoint:syscalls:sys_enter_openat { @open = count(); }
+tracepoint:syscalls:sys_enter_openat { @open = count(); }
 tracepoint:syscalls:sys_enter_read { @read = count(); }
 tracepoint:syscalls:sys_enter_write { @write = count(); }
 tracepoint:syscalls:sys_enter_recvmsg { @recvmsg = count(); }

--- a/src/datasources/bpftrace/dashboards/tools/tcpaccept.bt
+++ b/src/datasources/bpftrace/dashboards/tools/tcpaccept.bt
@@ -17,8 +17,17 @@
  */
 // table-retain-lines: 10
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+/*
+ * With BTF providing types, full headers are not needed.
+ * We only need to supply the preprocessor defines used in this script.
+ */
+#define AF_INET 2
+#define AF_INET6 10
+#endif
 
 BEGIN
 {
@@ -51,7 +60,7 @@ kretprobe:inet_csk_accept
 		$qmax  = $sk->sk_max_ack_backlog;
 
 		// Destination port is big endian, it must be flipped
-		$dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+		$dport = (uint16)(($dport >> 8) | (($dport << 8) & 0x00FF00));
 
 		time("%H:%M:%S,");
 		printf("%d,%s,", pid, comm);

--- a/src/datasources/bpftrace/dashboards/tools/tcpconnect.bt
+++ b/src/datasources/bpftrace/dashboards/tools/tcpconnect.bt
@@ -20,8 +20,17 @@
  */
 // table-retain-lines: 10
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+/*
+ * With BTF providing types, full headers are not needed.
+ * We only need to supply the preprocessor defines used in this script.
+ */
+#define AF_INET 2
+#define AF_INET6 10
+#endif
 
 BEGIN
 {
@@ -35,6 +44,9 @@ kprobe:tcp_connect
   $inet_family = $sk->__sk_common.skc_family;
 
   if ($inet_family == AF_INET || $inet_family == AF_INET6) {
+    // initialize variable type:
+    $daddr = ntop(0);
+    $saddr = ntop(0);
     if ($inet_family == AF_INET) {
       $daddr = ntop($sk->__sk_common.skc_daddr);
       $saddr = ntop($sk->__sk_common.skc_rcv_saddr);
@@ -46,7 +58,7 @@ kprobe:tcp_connect
     $dport = $sk->__sk_common.skc_dport;
 
     // Destination port is big endian, it must be flipped
-    $dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+    $dport = (uint16)(($dport >> 8) | (($dport << 8) & 0x00FF00));
 
     time("%H:%M:%S,");
     printf("%d,%s,", pid, comm);

--- a/src/datasources/bpftrace/dashboards/tools/tcpdrop.bt
+++ b/src/datasources/bpftrace/dashboards/tools/tcpdrop.bt
@@ -19,8 +19,17 @@
 // include: @output
 // table-retain-lines: 10
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+/*
+ * With BTF providing types, full headers are not needed.
+ * We only need to supply the preprocessor defines used in this script.
+ */
+#define AF_INET 2
+#define AF_INET6 10
+#endif
 
 BEGIN
 {
@@ -41,12 +50,15 @@ BEGIN
   @tcp_states[12] = "NEW_SYN_RECV";
 }
 
-kprobe:tcp_drop
+kprobe:tcp_drop_reason
 {
   $sk = ((struct sock *) arg0);
   $inet_family = $sk->__sk_common.skc_family;
 
   if ($inet_family == AF_INET || $inet_family == AF_INET6) {
+    // initialize variable type:
+    $daddr = ntop(0);
+    $saddr = ntop(0);
     if ($inet_family == AF_INET) {
       $daddr = ntop($sk->__sk_common.skc_daddr);
       $saddr = ntop($sk->__sk_common.skc_rcv_saddr);
@@ -58,7 +70,7 @@ kprobe:tcp_drop
     $dport = $sk->__sk_common.skc_dport;
 
     // Destination port is big endian, it must be flipped
-    $dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+    $dport = (uint16)(($dport >> 8) | (($dport << 8) & 0x00FF00));
 
     $state = $sk->__sk_common.skc_state;
     $statestr = @tcp_states[$state];

--- a/src/datasources/bpftrace/dashboards/tools/tcplife.bt
+++ b/src/datasources/bpftrace/dashboards/tools/tcplife.bt
@@ -15,10 +15,23 @@
 // include: @output
 // table-retain-lines: 10
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <net/tcp_states.h>
 #include <net/sock.h>
 #include <linux/socket.h>
 #include <linux/tcp.h>
+#else
+/*
+ * With BTF providing types, full headers are not needed.
+ * We only need to supply the preprocessor defines used in this script.
+ */
+#define AF_INET 2
+#define AF_INET6 10
+#define TCP_SYN_SENT 2
+#define TCP_FIN_WAIT1 4
+#define TCP_CLOSE 7
+#define TCP_LAST_ACK 9
+#endif
 
 BEGIN
 {
@@ -60,7 +73,7 @@ kprobe:tcp_set_state
 		$delta_ms = (nsecs - @birth[$sk]) / 1000000;
 		$lport = $sk->__sk_common.skc_num;
 		$dport = $sk->__sk_common.skc_dport;
-		$dport = ($dport >> 8) | (($dport << 8) & 0xff00);
+		$dport = (uint16)(($dport >> 8) | (($dport << 8) & 0xff00));
 		$tp = (struct tcp_sock *)$sk;
 		$pid = @skpid[$sk];
 		$comm = @skcomm[$sk];

--- a/src/datasources/bpftrace/dashboards/tools/tcpretrans.bt
+++ b/src/datasources/bpftrace/dashboards/tools/tcpretrans.bt
@@ -19,8 +19,17 @@
 // include: @output
 // table-retain-lines: 10
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+/*
+ * With BTF providing types, full headers are not needed.
+ * We only need to supply the preprocessor defines used in this script.
+ */
+#define AF_INET 2
+#define AF_INET6 10
+#endif
 
 BEGIN
 {
@@ -64,7 +73,7 @@ kprobe:tcp_retransmit_skb
 		$dport = $sk->__sk_common.skc_dport;
 
 		// Destination port is big endian, it must be flipped
-		$dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+		$dport = (uint16)(($dport >> 8) | (($dport << 8) & 0x00FF00));
 
 		$state = $sk->__sk_common.skc_state;
 		$statestr = @tcp_states[$state];


### PR DESCRIPTION
Several of the bundled bpftrace dashboard scripts fail to compile on recent kernels (tested on Debian 13 with kernel 6.1, arm64, BTF-enabled). 

Two issues came up repeatedly:

- Scripts `#include` raw kernel headers (linux/sched.h, net/sock.h, linux/socket.h, net/tcp_states.h) to get types and   constants. On BTF-enabled kernels these conflict with bpftrace's generated vmlinux.h and fail to compile standalone. The structs are already provided by BTF, so the includes are now gated behind `#ifndef BPFTRACE_HAVE_BTF`, with the handful of plain #define constants (TASK_RUNNING, AF_INET, AF_INET6, TCP states) supplied manually when BTF is available, since those aren't part of BTF.

- A couple of probes reference kernel functions that no longer exist on newer kernels: blk_account_io_start/done are commonly inlined away, and tcp_drop() was renamed to tcp_drop_reason(). biolatency.bt now uses the block_rq_issue/block_rq_complete tracepoints instead (keyed by dev+sector, since there's no request pointer there), and tcpdrop.bt uses tcp_drop_reason().

Also fixed a couple of smaller issues found along the way: an unused delete() return value warning, and tcpconnect.bt's $daddr/$saddr not being initialized before use in some branches.